### PR TITLE
Added share to GCconnex button to GCpedia template

### DIFF
--- a/skins/Vector/GCWeb/css/gcpedia.css
+++ b/skins/Vector/GCWeb/css/gcpedia.css
@@ -1,4 +1,4 @@
-﻿.btn-primary{
+.btn-primary{
 	color:#fff;
 	background-color:#1F1F72 !important;
 }
@@ -104,4 +104,19 @@
     width: 25px;
     margin:0 2px 3px 0;
 
+}
+
+/*Share to GCconnex action*/
+
+.gccon-share{
+    font-size:0.85em;
+    margin-right:8px;
+    margin-top: 7px;
+    display: inline-block;
+    text-align: center;
+    cursor: pointer;
+    border: 1px solid #047177;
+    padding:4px 7px;
+    border-radius: 4px;
+    
 }

--- a/skins/Vector/VectorTemplate.php
+++ b/skins/Vector/VectorTemplate.php
@@ -257,6 +257,11 @@ class VectorTemplate extends BaseTemplate {
 					<?php $this->renderNavigation( array( 'NAMESPACES', 'VARIANTS' ) ); ?>
 				</div>
 				<div id="right-navigation">
+                    <?php //Nick - adding in the share to GCconnex button to the template 
+                            //Added new style class gccon-share
+                            //Gets the site lang and puts it in the data-lang
+                    ?>
+                    <div class="pull-left"><script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "//gcconnex.gc.ca/mod/gc_api/widget/en/share-button.js"; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'gcconnex-jssdk'));</script> <div class="gccon-share btn-default" data-lang="<?php echo $wgLang->getCode(); ?>" ></div></div>
 					<?php $this->renderNavigation( array( 'VIEWS', 'ACTIONS', 'SEARCH' ) ); ?>
 				</div>
 			</div>


### PR DESCRIPTION
This takes the share to gcconnex widget button, restyles it and places it on the GCpedia template. This way all pages on the site can be shared to GCconnex.